### PR TITLE
Handle invalid sets with red flash and typed error codes

### DIFF
--- a/Assets/Scripts/CardSelectable.cs
+++ b/Assets/Scripts/CardSelectable.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -15,16 +16,26 @@ public class CardSelectable : MonoBehaviour, IPointerClickHandler
     [SerializeField] private Color   _ringColor    = new Color(0.45f, 0.75f, 1f, 0.9f);
     [SerializeField] private Vector2 _ringDistance = new Vector2(6f, 6f);
 
+    [Header("Failure flash")]
+    [SerializeField] private Color  _flashColor    = new Color(1f, 0.25f, 0.25f, 1f);
+    [SerializeField] private float  _flashHoldTime = 0.15f;
+    [SerializeField] private float  _flashFadeTime = 0.3f;
+
     private Card      _card;
     private CardHover _hover;
     private Outline   _ring;
+    private Image     _image;
+    private Color     _baseColor;
+    private Coroutine _flashRoutine;
 
     private void Awake()
     {
         _card  = GetComponent<Card>();
         _hover = GetComponent<CardHover>();
+        _image = GetComponent<Image>();
+        _baseColor = _image != null ? _image.color : Color.white;
 
-        if (GetComponent<Image>() != null)
+        if (_image != null)
         {
             _ring = gameObject.AddComponent<Outline>();
             _ring.effectColor    = _ringColor;
@@ -33,10 +44,17 @@ public class CardSelectable : MonoBehaviour, IPointerClickHandler
         }
     }
 
-    private void OnEnable()  => SelectionManager.Instance.SelectionChanged += OnSelectionChanged;
+    private void OnEnable()
+    {
+        SelectionManager.Instance.SelectionChanged += OnSelectionChanged;
+        SelectionManager.Instance.SelectionFailed  += OnSelectionFailed;
+    }
+
     private void OnDisable()
     {
         SelectionManager.Instance.SelectionChanged -= OnSelectionChanged;
+        SelectionManager.Instance.SelectionFailed  -= OnSelectionFailed;
+        StopFlash();
         // Ensure visual state is cleared if component is disabled mid-selection.
         _hover?.SetSelected(false);
         if (_ring != null) _ring.enabled = false;
@@ -53,5 +71,39 @@ public class CardSelectable : MonoBehaviour, IPointerClickHandler
         bool isSelected = staged.Contains(_card.Id);
         _hover?.SetSelected(isSelected);
         if (_ring != null) _ring.enabled = isSelected;
+    }
+
+    private void OnSelectionFailed(SetValidator.ValidationResult _)
+    {
+        if (!SelectionManager.Instance.Staged.Contains(_card.Id)) return;
+        StopFlash();
+        _flashRoutine = StartCoroutine(FlashRed());
+    }
+
+    private void StopFlash()
+    {
+        if (_flashRoutine == null) return;
+        StopCoroutine(_flashRoutine);
+        _flashRoutine = null;
+        if (_image != null) _image.color = _baseColor;
+    }
+
+    private IEnumerator FlashRed()
+    {
+        if (_image == null) yield break;
+        _image.color = new Color(_flashColor.r, _flashColor.g, _flashColor.b, _baseColor.a);
+        yield return new WaitForSeconds(_flashHoldTime);
+        float t = 0f;
+        while (t < _flashFadeTime)
+        {
+            t += Time.deltaTime;
+            _image.color = Color.Lerp(
+                new Color(_flashColor.r, _flashColor.g, _flashColor.b, _baseColor.a),
+                _baseColor,
+                t / _flashFadeTime);
+            yield return null;
+        }
+        _image.color = _baseColor;
+        _flashRoutine = null;
     }
 }

--- a/Assets/Scripts/GroupDragHandler.cs
+++ b/Assets/Scripts/GroupDragHandler.cs
@@ -89,7 +89,7 @@ public class GroupDragHandler : MonoBehaviour
         if (card == null) return;
 
         var staged = SelectionManager.Instance.Staged;
-        if (staged.Count <= 1) return; // primary only — nothing to coordinate
+        if (staged.Count == 0) return; // nothing staged to follow
 
         _activeDrag = drag;
         _followers.Clear();

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -62,12 +62,17 @@ public class SelectionManager
     /// Attempt to play the staged set. Runs SetValidator — the only place validation occurs.
     /// On success: fires SelectionCommitted then resets state.
     /// On failure: fires SelectionFailed, staged list unchanged.
-    /// No-op when not the player's turn or nothing is staged.
+    /// Returns true if the staged set passed validation and was committed.
     /// </summary>
-    /// <summary>Returns true if the staged set passed validation and was committed.</summary>
     public bool Commit()
     {
-        if (!IsPlayerTurn || _staged.Count == 0) return false;
+        if (!IsPlayerTurn)
+        {
+            if (_staged.Count > 0)
+                SelectionFailed?.Invoke(new SetValidator.ValidationResult { IsValid = false, Code = SetValidator.FailCode.NotYourTurn, FailReason = "Not your turn" });
+            return false;
+        }
+        if (_staged.Count == 0) return false;
 
         var result = SetValidator.Validate(_staged, _context);
         if (result.IsValid)

--- a/Assets/Scripts/SetValidator.cs
+++ b/Assets/Scripts/SetValidator.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 /// <summary>
-/// Pure logic class — zero Unity dependencies.
+/// Pure logic class — zero Unity dependencies except Debug logging.
 /// Single source of truth for all Guandan set and bomb rules.
 /// Unit-testable with plain NUnit, no scene required.
 /// </summary>
@@ -22,12 +23,22 @@ public static class SetValidator
         JokerBomb
     }
 
+    public enum FailCode
+    {
+        None,
+        NoCardsSelected,
+        NotAValidSet,
+        WrongSetType,   // must match the required set type
+        NotYourTurn,
+    }
+
     public class ValidationResult
     {
-        public bool    IsValid;
-        public SetType Type;
-        public string  Description;
-        public string  FailReason;
+        public bool     IsValid;
+        public SetType  Type;
+        public FailCode Code;
+        public string   Description;
+        public string   FailReason;
     }
 
     /// <summary>
@@ -54,13 +65,23 @@ public static class SetValidator
         GameContext context = null)
     {
         if (cards.Count == 0)
-            return Fail("No cards selected");
+        {
+            Debug.Log("[SetValidator] Validate: no cards selected.");
+            return Fail(FailCode.NoCardsSelected, "No cards selected");
+        }
 
         var trumpRank = context?.TrumpRank ?? Card.Rank.Two;
+        Debug.Log($"[SetValidator] Validate: {cards.Count} card(s), trump={trumpRank}");
+
         var result = TryIdentify(cards, trumpRank);
 
         if (result == null)
-            return Fail("Not a valid Guandan set");
+        {
+            Debug.Log("[SetValidator] Validate: not a valid Guandan set.");
+            return Fail(FailCode.NotAValidSet, "Not a valid Guandan set");
+        }
+
+        Debug.Log($"[SetValidator] Identified: {result.Type} — {result.Description}");
 
         if (context != null)
         {
@@ -69,12 +90,14 @@ public static class SetValidator
                 result.Type != context.RequiredType.Value &&
                 !IsBomb(result.Type))
             {
-                return Fail($"Must play a {FriendlyTypeName(context.RequiredType.Value)} or a bomb");
+                Debug.Log($"[SetValidator] Wrong type: need {context.RequiredType.Value}, got {result.Type}.");
+                return Fail(FailCode.WrongSetType, $"Must play a {FriendlyTypeName(context.RequiredType.Value)} or a bomb");
             }
 
             // TODO: implement MustBeat comparison (beat-previous check)
         }
 
+        Debug.Log($"[SetValidator] Valid: {result.Type} — {result.Description}");
         return result;
     }
 
@@ -391,6 +414,6 @@ public static class SetValidator
     private static ValidationResult Ok(SetType type, string desc) =>
         new ValidationResult { IsValid = true, Type = type, Description = desc };
 
-    private static ValidationResult Fail(string reason) =>
-        new ValidationResult { IsValid = false, FailReason = reason };
+    private static ValidationResult Fail(FailCode code, string reason = null) =>
+        new ValidationResult { IsValid = false, Code = code, FailReason = reason };
 }


### PR DESCRIPTION
  ## Summary
  - Failed submissions (invalid set, not your turn) now fire `SelectionFailed`
    consistently — including the previously silent `!IsPlayerTurn` path
  - Staged cards flash red on `SelectionFailed` via a coroutine in `CardSelectable`
  - `ValidationResult` gains a `FailCode` enum so downstream code (staging bar,
    announcement overlay #66) can switch on failure type rather than parse strings

This just validates that the set played is one of the required sets to play and does NOT do any comparisons with any previous played sets

  ## What's not in this PR
  - Textual error display — tracked in #66 (game announcement overlay)