### PR TITLE
48 player and team data model

### DIFF
--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -62,6 +62,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4a10869e0f89184409f3e69825cb9f85, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Player
+  syncMethod: 0
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
+  playerName: 
+  isReady: 0
+  isHost: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -408,6 +408,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &475566955
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 475566957}
+  - component: {fileID: 475566956}
+  m_Layer: 0
+  m_Name: SeatingManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &475566956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 475566955}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8882f81eae7d9f42ab4f2033bc7108d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SeatingManager
+--- !u!4 &475566957
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 475566955}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1017.3707, y: 559.6344, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameLogic/PlayerData.cs
+++ b/Assets/Scripts/GameLogic/PlayerData.cs
@@ -1,0 +1,34 @@
+/// <summary>
+/// Immutable data record for one player in a game session.
+///
+/// Seat index is determined by connection order: the player with the lowest Mirror
+/// connectionId gets seat 0, the next gets seat 1, and so on clockwise.
+/// Team membership is always <c>seatIndex % 2</c>, so seats {0, 2, 4} form team 0
+/// and seats {1, 3, 5} form team 1, guaranteeing teammates sit directly across from
+/// each other and the two teams alternate clockwise around the table.
+/// </summary>
+public sealed class PlayerData
+{
+    /// <summary>Clockwise seat index, 0-based. Seat 0 is the first player to connect.</summary>
+    public int SeatIndex { get; }
+
+    /// <summary>
+    /// Team this player belongs to. Always <c>SeatIndex % 2</c>.
+    /// Team 0 holds seats 0, 2, 4; team 1 holds seats 1, 3, 5.
+    /// </summary>
+    public int TeamIndex { get; }
+
+    /// <summary>Display name, sourced from <see cref="Player.playerName"/>.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Mirror network ID. Links back to the <see cref="Player"/> NetworkBehaviour.</summary>
+    public uint NetId { get; }
+
+    public PlayerData(int seatIndex, string displayName, uint netId)
+    {
+        SeatIndex   = seatIndex;
+        TeamIndex   = seatIndex % 2;
+        DisplayName = displayName;
+        NetId       = netId;
+    }
+}

--- a/Assets/Scripts/GameLogic/PlayerData.cs.meta
+++ b/Assets/Scripts/GameLogic/PlayerData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c74e01e0e7442f41ae6f0206f226921

--- a/Assets/Scripts/GameLogic/SeatingManager.cs
+++ b/Assets/Scripts/GameLogic/SeatingManager.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Holds the canonical seat-to-player mapping for the current game session and
+/// derives team membership and turn order from it.
+///
+/// Seating rule:
+///   Players are seated clockwise in ascending connectionId order (lowest → seat 0).
+///   <c>teamIndex = seatIndex % 2</c>, so seats {0, 2, 4} form team 0 and
+///   {1, 3, 5} form team 1. Teammates always sit directly across from each other
+///   and the two teams alternate clockwise around the table.
+///
+/// Turn order:
+///   Seats are visited in ascending order: 0 → 1 → 2 → … → (N−1) → 0.
+///   <see cref="NextSeat"/> wraps automatically.
+///
+/// Populated by <see cref="DealManager"/> (server-side) once all players have connected.
+/// Must be present as a scene object in GameScene.
+/// </summary>
+public class SeatingManager : MonoBehaviour
+{
+    public static SeatingManager Instance { get; private set; }
+
+    // ── Public state ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// All players indexed by seat. <c>Players[i].SeatIndex == i</c> is always true.
+    /// Empty until <see cref="BuildSeating"/> is called.
+    /// </summary>
+    public IReadOnlyList<PlayerData> Players { get; private set; } = System.Array.Empty<PlayerData>();
+
+    /// <summary>
+    /// Both teams. <c>Teams[0].TeamIndex == 0</c>, <c>Teams[1].TeamIndex == 1</c>.
+    /// Empty until <see cref="BuildSeating"/> is called.
+    /// </summary>
+    public IReadOnlyList<TeamData> Teams { get; private set; } = System.Array.Empty<TeamData>();
+
+    /// <summary>
+    /// Seat indices in clockwise play order: [0, 1, 2, …, N−1].
+    /// The round/turn manager decides which seat leads each trick.
+    /// </summary>
+    public IReadOnlyList<int> TurnOrder { get; private set; } = System.Array.Empty<int>();
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds the seating arrangement from a list of <see cref="Player"/> objects
+    /// already sorted by connectionId (exactly the ordering used in <see cref="DealManager"/>).
+    /// The player at index 0 gets seat 0, index 1 gets seat 1, and so on.
+    /// </summary>
+    public void BuildSeating(IReadOnlyList<Player> orderedPlayers)
+    {
+        int n = orderedPlayers.Count;
+        var players = new PlayerData[n];
+        var teamLists = new List<PlayerData>[2] { new(), new() };
+
+        for (int seat = 0; seat < n; seat++)
+        {
+            var p  = orderedPlayers[seat];
+            var pd = new PlayerData(seat, p.playerName, p.netId);
+            players[seat] = pd;
+            teamLists[pd.TeamIndex].Add(pd);
+        }
+
+        Players = players;
+        Teams = new TeamData[]
+        {
+            new TeamData(0, teamLists[0]),
+            new TeamData(1, teamLists[1]),
+        };
+
+        var order = new int[n];
+        for (int i = 0; i < n; i++) order[i] = i;
+        TurnOrder = order;
+
+        Debug.Log($"[SeatingManager] Seating built: {n} players | " +
+                  $"Team 0 seats: [{string.Join(", ", teamLists[0].ConvertAll(p => p.SeatIndex.ToString()))}] | " +
+                  $"Team 1 seats: [{string.Join(", ", teamLists[1].ConvertAll(p => p.SeatIndex.ToString()))}]");
+    }
+
+    /// <summary>
+    /// Returns the seat index that acts after <paramref name="currentSeat"/>,
+    /// wrapping from the last seat back to seat 0.
+    /// </summary>
+    public int NextSeat(int currentSeat) => (currentSeat + 1) % Players.Count;
+
+    /// <summary>
+    /// Returns the <see cref="PlayerData"/> at the given seat, or <c>null</c> if the
+    /// index is out of range.
+    /// </summary>
+    public PlayerData GetPlayer(int seatIndex)
+        => seatIndex >= 0 && seatIndex < Players.Count ? Players[seatIndex] : null;
+
+    /// <summary>
+    /// Returns the <see cref="TeamData"/> for the team that owns the given seat,
+    /// or <c>null</c> if the seat index is out of range.
+    /// </summary>
+    public TeamData GetTeamForSeat(int seatIndex)
+    {
+        var player = GetPlayer(seatIndex);
+        return player != null ? Teams[player.TeamIndex] : null;
+    }
+
+    /// <summary>
+    /// Returns the team index for a seat without requiring an instance.
+    /// Rule: <c>seatIndex % 2</c>.
+    /// </summary>
+    public static int TeamIndexForSeat(int seatIndex) => seatIndex % 2;
+}

--- a/Assets/Scripts/GameLogic/SeatingManager.cs
+++ b/Assets/Scripts/GameLogic/SeatingManager.cs
@@ -56,6 +56,12 @@ public class SeatingManager : MonoBehaviour
 
     private void Awake()
     {
+        if (Instance != null && Instance != this)
+        {
+            Debug.LogWarning("[SeatingManager] Duplicate instance destroyed.");
+            Destroy(gameObject);
+            return;
+        }
         Instance = this;
     }
 

--- a/Assets/Scripts/GameLogic/SeatingManager.cs
+++ b/Assets/Scripts/GameLogic/SeatingManager.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 ///
 /// Turn order:
 ///   Seats are visited in ascending order: 0 → 1 → 2 → … → (N−1) → 0.
-///   <see cref="NextSeat"/> wraps automatically.
+///   <see cref="NextSeat(int, int)"/> wraps automatically.
 ///
 /// Populated by <see cref="DealManager"/> (server-side) once all players have connected.
 /// Must be present as a scene object in GameScene.
@@ -42,6 +42,16 @@ public class SeatingManager : MonoBehaviour
     /// </summary>
     public IReadOnlyList<int> TurnOrder { get; private set; } = System.Array.Empty<int>();
 
+    // ── Nested type ───────────────────────────────────────────────────────────
+
+    /// <summary>Minimal player descriptor used by <see cref="BuildSeatingData"/>.</summary>
+    public readonly struct PlayerSlot
+    {
+        public readonly string DisplayName;
+        public readonly uint   NetId;
+        public PlayerSlot(string displayName, uint netId) { DisplayName = displayName; NetId = netId; }
+    }
+
     // ── Lifecycle ─────────────────────────────────────────────────────────────
 
     private void Awake()
@@ -63,20 +73,40 @@ public class SeatingManager : MonoBehaviour
     /// </summary>
     public void BuildSeating(IReadOnlyList<Player> orderedPlayers)
     {
-        int n = orderedPlayers.Count;
-        var players = new PlayerData[n];
+        var slots = new PlayerSlot[orderedPlayers.Count];
+        for (int i = 0; i < orderedPlayers.Count; i++)
+            slots[i] = new PlayerSlot(orderedPlayers[i].playerName, orderedPlayers[i].netId);
+
+        var (players, teams, order) = BuildSeatingData(slots);
+        Players   = players;
+        Teams     = teams;
+        TurnOrder = order;
+
+        Debug.Log($"[SeatingManager] Seating built: {players.Length} players | " +
+                  $"Team 0 seats: [{SeatList(teams[0].Players)}] | " +
+                  $"Team 1 seats: [{SeatList(teams[1].Players)}]");
+    }
+
+    /// <summary>
+    /// Pure seating logic with no Unity or Mirror dependencies. Assigns seats, teams,
+    /// and turn order from an ordered list of player descriptors.
+    /// Exposed as <c>public static</c> so it can be called directly from tests.
+    /// </summary>
+    public static (PlayerData[] players, TeamData[] teams, int[] turnOrder)
+        BuildSeatingData(IReadOnlyList<PlayerSlot> slots)
+    {
+        int n = slots.Count;
+        var players   = new PlayerData[n];
         var teamLists = new List<PlayerData>[2] { new(), new() };
 
         for (int seat = 0; seat < n; seat++)
         {
-            var p  = orderedPlayers[seat];
-            var pd = new PlayerData(seat, p.playerName, p.netId);
+            var pd = new PlayerData(seat, slots[seat].DisplayName, slots[seat].NetId);
             players[seat] = pd;
             teamLists[pd.TeamIndex].Add(pd);
         }
 
-        Players = players;
-        Teams = new TeamData[]
+        var teams = new TeamData[]
         {
             new TeamData(0, teamLists[0]),
             new TeamData(1, teamLists[1]),
@@ -84,18 +114,20 @@ public class SeatingManager : MonoBehaviour
 
         var order = new int[n];
         for (int i = 0; i < n; i++) order[i] = i;
-        TurnOrder = order;
 
-        Debug.Log($"[SeatingManager] Seating built: {n} players | " +
-                  $"Team 0 seats: [{string.Join(", ", teamLists[0].ConvertAll(p => p.SeatIndex.ToString()))}] | " +
-                  $"Team 1 seats: [{string.Join(", ", teamLists[1].ConvertAll(p => p.SeatIndex.ToString()))}]");
+        return (players, teams, order);
     }
 
     /// <summary>
     /// Returns the seat index that acts after <paramref name="currentSeat"/>,
     /// wrapping from the last seat back to seat 0.
     /// </summary>
-    public int NextSeat(int currentSeat) => (currentSeat + 1) % Players.Count;
+    public int NextSeat(int currentSeat) => NextSeat(currentSeat, Players.Count);
+
+    /// <summary>
+    /// Stateless overload — usable without an instance and in tests.
+    /// </summary>
+    public static int NextSeat(int currentSeat, int playerCount) => (currentSeat + 1) % playerCount;
 
     /// <summary>
     /// Returns the <see cref="PlayerData"/> at the given seat, or <c>null</c> if the
@@ -119,4 +151,11 @@ public class SeatingManager : MonoBehaviour
     /// Rule: <c>seatIndex % 2</c>.
     /// </summary>
     public static int TeamIndexForSeat(int seatIndex) => seatIndex % 2;
+
+    private static string SeatList(IReadOnlyList<PlayerData> players)
+    {
+        var parts = new string[players.Count];
+        for (int i = 0; i < players.Count; i++) parts[i] = players[i].SeatIndex.ToString();
+        return string.Join(", ", parts);
+    }
 }

--- a/Assets/Scripts/GameLogic/SeatingManager.cs.meta
+++ b/Assets/Scripts/GameLogic/SeatingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8882f81eae7d9f42ab4f2033bc7108d

--- a/Assets/Scripts/GameLogic/TeamData.cs
+++ b/Assets/Scripts/GameLogic/TeamData.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Immutable data record for one team in a game session.
+///
+/// In a 4-player game each team has 2 members; in a 6-player game, 3 members.
+/// Teammates always occupy seats that differ by 2 (directly across the table).
+/// </summary>
+public sealed class TeamData
+{
+    /// <summary>0 or 1. Equal to <c>seatIndex % 2</c> for any member of this team.</summary>
+    public int TeamIndex { get; }
+
+    /// <summary>All players on this team, ordered by ascending seat index.</summary>
+    public IReadOnlyList<PlayerData> Players { get; }
+
+    public TeamData(int teamIndex, IReadOnlyList<PlayerData> players)
+    {
+        TeamIndex = teamIndex;
+        Players   = players;
+    }
+}

--- a/Assets/Scripts/GameLogic/TeamData.cs
+++ b/Assets/Scripts/GameLogic/TeamData.cs
@@ -17,6 +17,7 @@ public sealed class TeamData
     public TeamData(int teamIndex, IReadOnlyList<PlayerData> players)
     {
         TeamIndex = teamIndex;
-        Players   = players;
+        Players   = new System.Collections.ObjectModel.ReadOnlyCollection<PlayerData>(
+                        new List<PlayerData>(players));
     }
 }

--- a/Assets/Scripts/GameLogic/TeamData.cs.meta
+++ b/Assets/Scripts/GameLogic/TeamData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92c04436b6971c3478cac40989efbc26

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -72,10 +72,12 @@ public class DealManager : NetworkBehaviour
         players.Sort((a, b) =>
             a.connectionToClient.connectionId.CompareTo(b.connectionToClient.connectionId));
 
-        if (SeatingManager.Instance != null)
-            SeatingManager.Instance.BuildSeating(players);
-        else
-            Debug.LogWarning("[DealManager] SeatingManager.Instance is null — seat/team data will not be available.");
+        if (SeatingManager.Instance == null)
+        {
+            Debug.LogError("[DealManager] SeatingManager.Instance is null — aborting deal.");
+            return;
+        }
+        SeatingManager.Instance.BuildSeating(players);
 
         int seed = Random.Range(1, int.MaxValue); // server owns the entropy
         var deck = _cardManager.GetShuffledDoubleDeck(seed);

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -72,6 +72,11 @@ public class DealManager : NetworkBehaviour
         players.Sort((a, b) =>
             a.connectionToClient.connectionId.CompareTo(b.connectionToClient.connectionId));
 
+        if (SeatingManager.Instance != null)
+            SeatingManager.Instance.BuildSeating(players);
+        else
+            Debug.LogWarning("[DealManager] SeatingManager.Instance is null — seat/team data will not be available.");
+
         int seed = Random.Range(1, int.MaxValue); // server owns the entropy
         var deck = _cardManager.GetShuffledDoubleDeck(seed);
 

--- a/Assets/Tests/Editor/SeatingTests.cs
+++ b/Assets/Tests/Editor/SeatingTests.cs
@@ -1,0 +1,126 @@
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for SeatingManager's pure seating logic.
+/// All tests call SeatingManager.BuildSeatingData directly — no scene or Mirror required.
+/// </summary>
+public class SeatingTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    static SeatingManager.PlayerSlot[] Slots(int count)
+    {
+        var slots = new SeatingManager.PlayerSlot[count];
+        for (int i = 0; i < count; i++)
+            slots[i] = new SeatingManager.PlayerSlot($"Player {i}", (uint)i);
+        return slots;
+    }
+
+    // ── Team assignment — 4 players ───────────────────────────────────────────
+
+    [Test]
+    public void FourPlayers_Team0_HasSeats0And2()
+    {
+        var (_, teams, _) = SeatingManager.BuildSeatingData(Slots(4));
+        Assert.AreEqual(2, teams[0].Players.Count);
+        Assert.AreEqual(0, teams[0].Players[0].SeatIndex);
+        Assert.AreEqual(2, teams[0].Players[1].SeatIndex);
+    }
+
+    [Test]
+    public void FourPlayers_Team1_HasSeats1And3()
+    {
+        var (_, teams, _) = SeatingManager.BuildSeatingData(Slots(4));
+        Assert.AreEqual(2, teams[1].Players.Count);
+        Assert.AreEqual(1, teams[1].Players[0].SeatIndex);
+        Assert.AreEqual(3, teams[1].Players[1].SeatIndex);
+    }
+
+    // ── Team assignment — 6 players ───────────────────────────────────────────
+
+    [Test]
+    public void SixPlayers_Team0_HasSeats0_2_4()
+    {
+        var (_, teams, _) = SeatingManager.BuildSeatingData(Slots(6));
+        Assert.AreEqual(3, teams[0].Players.Count);
+        Assert.AreEqual(0, teams[0].Players[0].SeatIndex);
+        Assert.AreEqual(2, teams[0].Players[1].SeatIndex);
+        Assert.AreEqual(4, teams[0].Players[2].SeatIndex);
+    }
+
+    [Test]
+    public void SixPlayers_Team1_HasSeats1_3_5()
+    {
+        var (_, teams, _) = SeatingManager.BuildSeatingData(Slots(6));
+        Assert.AreEqual(3, teams[1].Players.Count);
+        Assert.AreEqual(1, teams[1].Players[0].SeatIndex);
+        Assert.AreEqual(3, teams[1].Players[1].SeatIndex);
+        Assert.AreEqual(5, teams[1].Players[2].SeatIndex);
+    }
+
+    // ── PlayerData fields ─────────────────────────────────────────────────────
+
+    [Test]
+    public void PlayerData_TeamIndex_EqualsSeatModTwo()
+    {
+        var (players, _, _) = SeatingManager.BuildSeatingData(Slots(6));
+        foreach (var p in players)
+            Assert.AreEqual(p.SeatIndex % 2, p.TeamIndex,
+                $"Seat {p.SeatIndex} should be team {p.SeatIndex % 2}");
+    }
+
+    [Test]
+    public void PlayerData_SeatIndex_MatchesPositionInArray()
+    {
+        var (players, _, _) = SeatingManager.BuildSeatingData(Slots(4));
+        for (int i = 0; i < players.Length; i++)
+            Assert.AreEqual(i, players[i].SeatIndex);
+    }
+
+    // ── Turn order ────────────────────────────────────────────────────────────
+
+    [Test]
+    public void TurnOrder_4Players_IsSequential()
+    {
+        var (_, _, order) = SeatingManager.BuildSeatingData(Slots(4));
+        Assert.AreEqual(new[] { 0, 1, 2, 3 }, order);
+    }
+
+    [Test]
+    public void TurnOrder_6Players_IsSequential()
+    {
+        var (_, _, order) = SeatingManager.BuildSeatingData(Slots(6));
+        Assert.AreEqual(new[] { 0, 1, 2, 3, 4, 5 }, order);
+    }
+
+    // ── NextSeat wrapping ─────────────────────────────────────────────────────
+
+    [Test]
+    public void NextSeat_4Players_WrapsAt3()
+    {
+        Assert.AreEqual(0, SeatingManager.NextSeat(3, 4));
+    }
+
+    [Test]
+    public void NextSeat_6Players_WrapsAt5()
+    {
+        Assert.AreEqual(0, SeatingManager.NextSeat(5, 6));
+    }
+
+    [Test]
+    public void NextSeat_MidTable_Increments()
+    {
+        Assert.AreEqual(2, SeatingManager.NextSeat(1, 4));
+        Assert.AreEqual(3, SeatingManager.NextSeat(2, 6));
+    }
+
+    // ── TeamIndexForSeat ──────────────────────────────────────────────────────
+
+    [Test]
+    public void TeamIndexForSeat_AlternatesCorrectly()
+    {
+        for (int seat = 0; seat < 6; seat++)
+            Assert.AreEqual(seat % 2, SeatingManager.TeamIndexForSeat(seat),
+                $"Seat {seat} should map to team {seat % 2}");
+    }
+}

--- a/Assets/Tests/Editor/SeatingTests.cs.meta
+++ b/Assets/Tests/Editor/SeatingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14e10538e87f5f0418e50663a2e4676c


### PR DESCRIPTION
Introduces the core data model for players, teams, seat assignment, and turn order

What's added

- PlayerData — immutable record holding a player's seat index, team index (seatIndex % 2), display name, and Mirror net ID
- TeamData — immutable record holding a team index and its ordered list of players
- SeatingManager — MonoBehaviour singleton that builds and exposes the seating arrangement; populated by DealManager once all players have connected
- DealManager updated to call SeatingManager.BuildSeating() using the same connectionId-sorted player list used for dealing, keeping seat indices and deal order consistent
- 11 EditMode tests covering team assignment for 4 and 6 players, PlayerData fields, turn order, NextSeat wrapping, and TeamIndexForSeat

Team assignment rule
`teamIndex = seatIndex % 2` — seats {0, 2, 4} form team 0, seats {1, 3, 5} form team 1. Teammates always sit directly across from each other and the two teams alternate clockwise, matching the game rules.

Verified
Tested with 2 and 4 player instances. With 4 players the log confirms: `Team 0 seats: [0, 2] | Team 1 seats: [1, 3].`