### PR TITLE
61 turn and action synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ UpgradeLog*.htm
 UpgradeLog*.html
 
 .claude
+
+Resources/*.json

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -119,43 +119,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &41542269
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 41542270}
-  m_Layer: 0
-  m_Name: HUD
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &41542270
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 41542269}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1530123406}
-  - {fileID: 968344790}
-  m_Father: {fileID: 99944909}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &65009802
 GameObject:
   m_ObjectHideFlags: 0
@@ -1140,7 +1103,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 940168593}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1741,7 +1704,6 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1530123405}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.56, y: 0.56, z: 1.3333334}
@@ -2607,3 +2569,4 @@ SceneRoots:
   - {fileID: 379525480}
   - {fileID: 475566957}
   - {fileID: 1731515874}
+  - {fileID: 842725525}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -287,7 +287,7 @@ RectTransform:
   m_Children:
   - {fileID: 1673787566}
   - {fileID: 1243539247}
-  - {fileID: 41542270}
+  - {fileID: 986879879}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -295,7 +295,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &129024493
+--- !u!1 &164068481
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -303,9 +303,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 129024494}
-  - component: {fileID: 129024496}
-  - component: {fileID: 129024495}
+  - component: {fileID: 164068482}
+  - component: {fileID: 164068484}
+  - component: {fileID: 164068483}
   m_Layer: 5
   m_Name: Text
   m_TagString: Untagged
@@ -313,32 +313,32 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &129024494
+--- !u!224 &164068482
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 129024493}
+  m_GameObject: {fileID: 164068481}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 131564619}
+  m_Father: {fileID: 2030759599}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &129024495
+--- !u!114 &164068483
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 129024493}
+  m_GameObject: {fileID: 164068481}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
@@ -424,134 +424,13 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &129024496
+--- !u!222 &164068484
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 129024493}
-  m_CullTransparentMesh: 1
---- !u!1 &131564618
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 131564619}
-  - component: {fileID: 131564622}
-  - component: {fileID: 131564621}
-  - component: {fileID: 131564620}
-  m_Layer: 5
-  m_Name: PlayButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &131564619
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131564618}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 129024494}
-  m_Father: {fileID: 968344790}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -310, y: -50}
-  m_SizeDelta: {x: 200, y: 100}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &131564620
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131564618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.20392157}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.43137255}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 131564621}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &131564621
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131564618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &131564622
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131564618}
+  m_GameObject: {fileID: 164068481}
   m_CullTransparentMesh: 1
 --- !u!1 &294219265
 GameObject:
@@ -1413,7 +1292,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &940168592
+--- !u!1 &986879878
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1421,10 +1300,193 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 940168593}
-  - component: {fileID: 940168596}
-  - component: {fileID: 940168595}
-  - component: {fileID: 940168594}
+  - component: {fileID: 986879879}
+  - component: {fileID: 986879880}
+  m_Layer: 0
+  m_Name: HUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &986879879
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986879878}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -60.503265, y: 24.672043, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1530123406}
+  - {fileID: 2026436171}
+  m_Father: {fileID: 99944909}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &986879880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 986879878}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de1592ce675dc8348a24911d743dabf0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GameHUD
+--- !u!1 &992431233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 992431234}
+  - component: {fileID: 992431236}
+  - component: {fileID: 992431235}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &992431234
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 992431233}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 992947940}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &992431235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 992431233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: PASS
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 0157a296901d24849a83dfc2b88cfdd3, type: 2}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 70
+  m_fontSizeBase: 70
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &992431236
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 992431233}
+  m_CullTransparentMesh: 1
+--- !u!1 &992947939
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 992947940}
+  - component: {fileID: 992947943}
+  - component: {fileID: 992947942}
+  - component: {fileID: 992947941}
   m_Layer: 5
   m_Name: PassButton
   m_TagString: Untagged
@@ -1432,33 +1494,33 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &940168593
+--- !u!224 &992947940
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940168592}
+  m_GameObject: {fileID: 992947939}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 842725525}
-  m_Father: {fileID: 968344790}
+  - {fileID: 992431234}
+  m_Father: {fileID: 2026436171}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 110, y: -50}
   m_SizeDelta: {x: 200, y: 100}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &940168594
+--- !u!114 &992947941
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940168592}
+  m_GameObject: {fileID: 992947939}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -1492,17 +1554,29 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 940168595}
+  m_TargetGraphic: {fileID: 992947942}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
---- !u!114 &940168595
+      m_Calls:
+      - m_Target: {fileID: 986879880}
+        m_TargetAssemblyTypeName: GameHUD, Assembly-CSharp
+        m_MethodName: OnPassClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &992947942
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940168592}
+  m_GameObject: {fileID: 992947939}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -1526,51 +1600,14 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!222 &940168596
+--- !u!222 &992947943
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 940168592}
+  m_GameObject: {fileID: 992947939}
   m_CullTransparentMesh: 1
---- !u!1 &968344789
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 968344790}
-  m_Layer: 0
-  m_Name: ActionBar
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &968344790
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 968344789}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 131564619}
-  - {fileID: 940168593}
-  m_Father: {fileID: 41542270}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 150}
-  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &1243539246
 GameObject:
   m_ObjectHideFlags: 0
@@ -1705,17 +1742,18 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1530123405}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.42000002, y: 0.42000002, z: 1}
+  m_LocalScale: {x: 0.56, y: 0.56, z: 1.3333334}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1855772535}
-  m_Father: {fileID: 41542270}
+  m_Father: {fileID: 986879879}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 150}
-  m_SizeDelta: {x: 1254, y: 300}
+  m_AnchorMax: {x: 1, y: 0.3}
+  m_AnchoredPosition: {x: 65.170044, y: -571.39}
+  m_SizeDelta: {x: 3175.3608, y: 484}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1530123407
 MonoBehaviour:
@@ -2382,6 +2420,176 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &2026436170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2026436171}
+  m_Layer: 0
+  m_Name: ActionBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2026436171
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2026436170}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.3333299, y: 1.3333299, z: 1.3333299}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2030759599}
+  - {fileID: 992947940}
+  m_Father: {fileID: 986879879}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 80.67102, y: -752.8942}
+  m_SizeDelta: {x: 1920, y: 150}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!1 &2030759598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2030759599}
+  - component: {fileID: 2030759602}
+  - component: {fileID: 2030759601}
+  - component: {fileID: 2030759600}
+  m_Layer: 5
+  m_Name: PlayButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2030759599
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030759598}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 164068482}
+  m_Father: {fileID: 2026436171}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -310, y: -50}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &2030759600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030759598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.20392157}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.43137255}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2030759601}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 986879880}
+        m_TargetAssemblyTypeName: GameHUD, Assembly-CSharp
+        m_MethodName: OnPlayClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2030759601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030759598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2030759602
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030759598}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1380,6 +1380,7 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
+  _devSoloMode: 1
 --- !u!114 &1731515873
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1346,6 +1346,72 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1731515871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1731515874}
+  - component: {fileID: 1731515873}
+  - component: {fileID: 1731515872}
+  m_Layer: 0
+  m_Name: TurnManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1731515872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731515871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3435844ea8ddc8f4a91c739d3b96b192, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::TurnManager
+  syncMethod: 0
+  syncDirection: 0
+  syncMode: 0
+  syncInterval: 0
+--- !u!114 &1731515873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731515871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mirror::Mirror.NetworkIdentity
+  sceneId: 1502372347
+  _assetId: 0
+  serverOnly: 0
+  visibility: 0
+  hasSpawned: 0
+--- !u!4 &1731515874
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731515871}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1017.3707, y: 559.6344, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1800541390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1741,3 +1807,5 @@ SceneRoots:
   - {fileID: 1704199694}
   - {fileID: 931816168}
   - {fileID: 379525480}
+  - {fileID: 475566957}
+  - {fileID: 1731515874}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -119,6 +119,43 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &41542269
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 41542270}
+  m_Layer: 0
+  m_Name: HUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &41542270
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41542269}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1530123406}
+  - {fileID: 968344790}
+  m_Father: {fileID: 99944909}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &65009802
 GameObject:
   m_ObjectHideFlags: 0
@@ -231,7 +268,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
@@ -249,8 +286,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1673787566}
-  - {fileID: 1530123406}
   - {fileID: 1243539247}
+  - {fileID: 41542270}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -258,6 +295,264 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &129024493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 129024494}
+  - component: {fileID: 129024496}
+  - component: {fileID: 129024495}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &129024494
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 129024493}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 131564619}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &129024495
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 129024493}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: PLAY
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 0157a296901d24849a83dfc2b88cfdd3, type: 2}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 70
+  m_fontSizeBase: 70
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &129024496
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 129024493}
+  m_CullTransparentMesh: 1
+--- !u!1 &131564618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 131564619}
+  - component: {fileID: 131564622}
+  - component: {fileID: 131564621}
+  - component: {fileID: 131564620}
+  m_Layer: 5
+  m_Name: PlayButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &131564619
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131564618}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 129024494}
+  m_Father: {fileID: 968344790}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -310, y: -50}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &131564620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131564618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.20392157}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.43137255}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 131564621}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &131564621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131564618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &131564622
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131564618}
+  m_CullTransparentMesh: 1
 --- !u!1 &294219265
 GameObject:
   m_ObjectHideFlags: 0
@@ -936,6 +1231,143 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &842725524
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 842725525}
+  - component: {fileID: 842725527}
+  - component: {fileID: 842725526}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &842725525
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842725524}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 940168593}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &842725526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842725524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: PASS
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 0157a296901d24849a83dfc2b88cfdd3, type: 2}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 70
+  m_fontSizeBase: 70
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &842725527
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842725524}
+  m_CullTransparentMesh: 1
 --- !u!1 &931816166
 GameObject:
   m_ObjectHideFlags: 0
@@ -981,6 +1413,164 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &940168592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 940168593}
+  - component: {fileID: 940168596}
+  - component: {fileID: 940168595}
+  - component: {fileID: 940168594}
+  m_Layer: 5
+  m_Name: PassButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &940168593
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940168592}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 842725525}
+  m_Father: {fileID: 968344790}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 110, y: -50}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &940168594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940168592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0.20392157}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.43137255}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 0}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 940168595}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &940168595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940168592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &940168596
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940168592}
+  m_CullTransparentMesh: 1
+--- !u!1 &968344789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 968344790}
+  m_Layer: 0
+  m_Name: ActionBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &968344790
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968344789}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 131564619}
+  - {fileID: 940168593}
+  m_Father: {fileID: 41542270}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 150}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &1243539246
 GameObject:
   m_ObjectHideFlags: 0
@@ -1114,18 +1704,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1530123405}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.42, y: 0.42, z: 1}
+  m_LocalScale: {x: 0.42000002, y: 0.42000002, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1855772535}
-  m_Father: {fileID: 99944909}
+  m_Father: {fileID: 41542270}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.3}
-  m_AnchoredPosition: {x: -11.625732, y: 0}
-  m_SizeDelta: {x: 1255.3608, y: 160}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 150}
+  m_SizeDelta: {x: 1254, y: 300}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1530123407
 MonoBehaviour:
@@ -1134,7 +1724,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1530123405}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
   m_Name: 
@@ -1224,10 +1814,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 99944909}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.064819336, y: 0.0024414062}
+  m_SizeDelta: {x: -1813.6, y: -981.82}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1673787567
 MonoBehaviour:
@@ -1380,7 +1970,6 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
-  _devSoloMode: 1
 --- !u!114 &1731515873
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardHover.cs
+++ b/Assets/Scripts/CardHover.cs
@@ -23,6 +23,38 @@ public class CardHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
     /// </summary>
     public static event Action<Card.CardId, bool> AnyHoverChanged;
 
+    /// <summary>Set by CardDrag — suppresses hover effects while any card is being dragged.</summary>
+    public static bool IsDragging { get; private set; }
+
+    private void OnEnable()
+    {
+        CardDrag.AnyDragBegin += OnAnyDragBegin;
+        CardDrag.AnyDragEnd   += OnAnyDragEnd;
+    }
+
+    private void OnDisable()
+    {
+        CardDrag.AnyDragBegin -= OnAnyDragBegin;
+        CardDrag.AnyDragEnd   -= OnAnyDragEnd;
+    }
+
+    private void OnAnyDragBegin(CardDrag _)
+    {
+        IsDragging = true;
+        // Clear hover state on this card so it doesn't stay lit while another card is dragged.
+        if (_isHovered)
+        {
+            _isHovered = false;
+            UpdateVisuals();
+            if (_card != null) AnyHoverChanged?.Invoke(_card.Id, false);
+        }
+    }
+
+    private void OnAnyDragEnd(CardDrag _)
+    {
+        IsDragging = false;
+    }
+
     private void Awake()
     {
         _card = GetComponent<Card>();
@@ -39,6 +71,7 @@ public class CardHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
 
     public void OnPointerEnter(PointerEventData eventData)
     {
+        if (IsDragging) return;
         _isHovered = true;
         UpdateVisuals();
         if (_card != null) AnyHoverChanged?.Invoke(_card.Id, true);

--- a/Assets/Scripts/GameLogic/TrickManager.cs
+++ b/Assets/Scripts/GameLogic/TrickManager.cs
@@ -3,21 +3,34 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// Tracks the state of the current trick: the controlling set and the required set type.
-/// Builds and injects GameContext into SelectionManager on every state change so that
-/// SetValidator always validates against the current table.
+/// Tracks the state of the current trick: the controlling set on the table and the play history.
+/// State is driven exclusively by TurnManager RPCs — never by local SelectionManager events.
 ///
-/// Turn enforcement (whose turn it is, pass counting) is not yet implemented.
-/// When TurnManager arrives it will call StartTrick() and gate player input;
-/// this class's interface will not change.
+/// TurnManager calls:
+///   ApplyPlay  — after the server validates a card play and broadcasts it to all clients.
+///   ApplyPass  — after the server broadcasts a pass.
+///   StartTrick — after all remaining players pass, starting a new trick.
+///   SetTrumpRank — once at game start, before the first trick.
 /// </summary>
 public class TrickManager : MonoBehaviour
 {
+    public static TrickManager Instance { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+    }
+
     // ── Nested types ─────────────────────────────────────────────────────────
 
     /// <summary>
-    /// One play within a trick. PlayerId is -1 until TurnManager assigns real player IDs.
-    /// Designed to be network-serialization-friendly (value types + immutable list).
+    /// One play within a trick. PlayerId is the seat index of the player who played.
     /// </summary>
     public readonly struct PlayRecord
     {
@@ -35,10 +48,6 @@ public class TrickManager : MonoBehaviour
 
     // ── Inspector ─────────────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Dev-time default used until DealManager exists to supply the trump rank per deal.
-    /// At that point this field will be set via a method call and the SerializeField removed.
-    /// </summary>
     [SerializeField] private Card.Rank _trumpRank = Card.Rank.Two;
 
     // ── Public state ──────────────────────────────────────────────────────────
@@ -46,8 +55,6 @@ public class TrickManager : MonoBehaviour
     /// <summary>
     /// The set currently on the table that subsequent players must beat.
     /// Null when the trick is open (the leader has not yet played).
-    /// Callers must not hold onto the returned reference across frames;
-    /// it is replaced (not mutated) on every <see cref="StartTrick"/> or commit.
     /// </summary>
     public SetValidator.ValidationResult ControllingSet { get; private set; }
 
@@ -56,7 +63,11 @@ public class TrickManager : MonoBehaviour
 
     // ── Events ────────────────────────────────────────────────────────────────
 
-    /// <summary>Fired after a set is committed and recorded. Subscribe for display/networking.</summary>
+    /// <summary>
+    /// Fired after a set is applied and recorded. PlayRecord.PlayerId is the seat index.
+    /// TableDisplay uses this to render remote plays; local plays are already animated
+    /// via HandManager.CardsPlayed before this fires.
+    /// </summary>
     public event Action<PlayRecord> SetPlayed;
 
     /// <summary>Fired after trick state is reset. Subscribe to clear the table display.</summary>
@@ -66,20 +77,32 @@ public class TrickManager : MonoBehaviour
 
     private readonly List<PlayRecord> _history = new();
 
-    // ── Lifecycle ─────────────────────────────────────────────────────────────
-
-    private void OnEnable()  => SelectionManager.Instance.SelectionCommitted += OnSetCommitted;
-    private void OnDisable() => SelectionManager.Instance.SelectionCommitted -= OnSetCommitted;
-
-    // TODO: remove once DealManager exists. DealManager should call StartTrick() for the
-    // first trick of each deal; TurnManager should call it for every subsequent trick.
-    private void Start() => StartTrick();
-
     // ── Public API ────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Resets trick state. Call when all other players have passed and a new trick begins.
-    /// Also exposed as a context menu item for manual testing in the Inspector.
+    /// Records a validated play from any player. Called by TurnManager.RpcApplyPlay on all clients.
+    /// Updates the controlling set, pushes context into SelectionManager, and fires SetPlayed.
+    /// </summary>
+    public void ApplyPlay(int seatIndex, IReadOnlyList<Card.CardId> cards, SetValidator.ValidationResult result)
+    {
+        ControllingSet = result;
+        var record = new PlayRecord(seatIndex, cards, result);
+        _history.Add(record);
+        PushContext();
+        SetPlayed?.Invoke(record);
+    }
+
+    /// <summary>
+    /// Records a pass from a player. Called by TurnManager.RpcApplyPass on all clients.
+    /// Currently a no-op beyond logging; pass history could be surfaced via TrickHistory if needed.
+    /// </summary>
+    public void ApplyPass(int seatIndex)
+    {
+        Debug.Log($"[TrickManager] Seat {seatIndex} passed.");
+    }
+
+    /// <summary>
+    /// Resets trick state. Called by TurnManager.RpcStartNewTrick and at game start.
     /// </summary>
     [ContextMenu("Start New Trick")]
     public void StartTrick()
@@ -90,16 +113,16 @@ public class TrickManager : MonoBehaviour
         TrickStarted?.Invoke();
     }
 
-    // ── Private ───────────────────────────────────────────────────────────────
-
-    private void OnSetCommitted(IReadOnlyList<Card.CardId> cards, SetValidator.ValidationResult result)
+    /// <summary>
+    /// Sets the trump rank for the current deal. Called by TurnManager.RpcSyncGameStart.
+    /// </summary>
+    public void SetTrumpRank(Card.Rank rank)
     {
-        ControllingSet = result;
-        var record = new PlayRecord(-1, cards, result);
-        _history.Add(record);
+        _trumpRank = rank;
         PushContext();
-        SetPlayed?.Invoke(record);
     }
+
+    // ── Private ───────────────────────────────────────────────────────────────
 
     private void PushContext()
     {

--- a/Assets/Scripts/GameLogic/TurnManager.cs
+++ b/Assets/Scripts/GameLogic/TurnManager.cs
@@ -1,0 +1,268 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Mirror;
+
+/// <summary>
+/// Server-authoritative turn manager. Validates plays server-side, broadcasts
+/// accepted plays and passes to all clients, and enforces turn order.
+///
+/// Flow for a card play:
+///   1. Local player commits → SelectionManager.SelectionCommitted fires
+///   2. TurnManager hears it → calls Player.LocalPlayer.CmdPlayCards
+///   3. Server: ServerHandlePlay validates the play; rejects or broadcasts RpcApplyPlay
+///   4. All clients: TrickManager.ApplyPlay updates state and fires SetPlayed
+///   5. Server: AdvanceTurn → _currentSeat SyncVar propagates → IsPlayerTurn updated
+///
+/// Flow for a pass:
+///   1. Local player passes → SelectionManager.Passed fires
+///   2. TurnManager → Player.LocalPlayer.CmdPass → ServerHandlePass
+///   3. Server: RpcApplyPass broadcast; trick-end check; AdvanceTurn or RpcStartNewTrick
+///   4. All clients: TrickManager updated; IsPlayerTurn updated via SyncVar hook
+///
+/// Must be placed as a scene NetworkBehaviour (NetworkIdentity on the same GameObject).
+/// </summary>
+public class TurnManager : NetworkBehaviour
+{
+    public static TurnManager Instance { get; private set; }
+
+    // ── Networked state ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seat index of the player whose turn it is. -1 means the game has not started.
+    /// The hook fires on all clients (including host) whenever this changes.
+    /// </summary>
+    [SyncVar(hook = nameof(OnCurrentSeatChanged))]
+    private int _currentSeat = -1;
+
+    /// <summary>Trump rank for the current deal. Synced to all clients at game start.</summary>
+    [SyncVar]
+    private Card.Rank _trumpRank = Card.Rank.Two;
+    public Card.Rank TrumpRank => _trumpRank;
+
+    // ── Server-only state ──────────────────────────────────────────────────────
+
+    /// <summary>Consecutive passes since the last play. Reset to 0 whenever a card set is played.</summary>
+    private int _passCount;
+
+    /// <summary>Seat that last played a card set. Used to determine who leads the next trick.</summary>
+    private int _lastPlaySeat = -1;
+
+    // ── Properties ────────────────────────────────────────────────────────────
+
+    /// <summary>Seat index of the local player. -1 until DealManager assigns seating.</summary>
+    public int LocalSeat => Player.LocalPlayer != null ? Player.LocalPlayer.SeatIndex : -1;
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+    }
+
+    private void OnEnable()
+    {
+        // Disable input until TurnManager assigns the turn.
+        SelectionManager.Instance.IsPlayerTurn = false;
+
+        SelectionManager.Instance.SelectionCommitted += OnLocalCommit;
+        SelectionManager.Instance.Passed             += OnLocalPass;
+    }
+
+    private void OnDisable()
+    {
+        SelectionManager.Instance.SelectionCommitted -= OnLocalCommit;
+        SelectionManager.Instance.Passed             -= OnLocalPass;
+    }
+
+    // ── Local event handlers → Commands ───────────────────────────────────────
+
+    private void OnLocalCommit(IReadOnlyList<Card.CardId> cards, SetValidator.ValidationResult _)
+    {
+        if (Player.LocalPlayer == null) return;
+        var arr = new Card.CardId[cards.Count];
+        for (int i = 0; i < cards.Count; i++) arr[i] = cards[i];
+        Player.LocalPlayer.CmdPlayCards(arr);
+    }
+
+    private void OnLocalPass()
+    {
+        Player.LocalPlayer?.CmdPass();
+    }
+
+    // ── Public server API ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Called by DealManager after all hands have been dealt.
+    /// Sets the trump rank, designates the lead seat, and opens the first trick.
+    /// </summary>
+    [Server]
+    public void StartGame(int leadSeat, Card.Rank trumpRank)
+    {
+        _trumpRank   = trumpRank;
+        _passCount   = 0;
+        _lastPlaySeat = leadSeat;
+
+        RpcSyncGameStart(trumpRank);
+
+        // _currentSeat SyncVar change triggers OnCurrentSeatChanged on all clients.
+        _currentSeat = leadSeat;
+
+        TrickManager.Instance.StartTrick();
+        Debug.Log($"[TurnManager] Game started. Lead seat: {leadSeat}, Trump: {trumpRank}");
+    }
+
+    // ── Server-side action handlers (called from Player Commands) ─────────────
+
+    /// <summary>
+    /// Validates a play submitted by <paramref name="player"/> and, if valid, broadcasts
+    /// it to all clients. Called from Player.CmdPlayCards on the server.
+    /// </summary>
+    [Server]
+    public void ServerHandlePlay(Player player, Card.CardId[] cards)
+    {
+        int seat = player.SeatIndex;
+        if (seat < 0 || seat != _currentSeat)
+        {
+            TargetRpcRejectAction(player.connectionToClient, "Not your turn");
+            return;
+        }
+
+        var context = new SetValidator.GameContext
+        {
+            MustBeat     = TrickManager.Instance.ControllingSet,
+            RequiredType = TrickManager.Instance.ControllingSet?.Type,
+            TrumpRank    = TrumpRank,
+        };
+
+        SetValidator.ValidationResult result = SetValidator.Validate(cards, context);
+        if (!result.IsValid)
+        {
+            TargetRpcRejectAction(player.connectionToClient, result.FailReason);
+            return;
+        }
+
+        if (!DealManager.Instance.TryConsumeCards(player.netId, cards))
+        {
+            TargetRpcRejectAction(player.connectionToClient, "You don't hold those cards");
+            return;
+        }
+
+        _passCount    = 0;
+        _lastPlaySeat = seat;
+
+        RpcApplyPlay(seat, cards);
+        AdvanceTurn();
+    }
+
+    /// <summary>
+    /// Records a pass submitted by <paramref name="player"/>. If all other players have
+    /// passed, ends the current trick and starts a new one. Called from Player.CmdPass.
+    /// </summary>
+    [Server]
+    public void ServerHandlePass(Player player)
+    {
+        int seat = player.SeatIndex;
+        if (seat < 0 || seat != _currentSeat) return;
+
+        // The leader of a new trick must play — passing is only valid once a set is on the table.
+        if (TrickManager.Instance.ControllingSet == null)
+        {
+            TargetRpcRejectAction(player.connectionToClient, "Must play to lead a trick");
+            return;
+        }
+
+        _passCount++;
+        RpcApplyPass(seat);
+
+        int playerCount = SeatingManager.Instance.Players.Count;
+        if (_passCount >= playerCount - 1)
+        {
+            // Everyone else has passed; the player who last played leads the next trick.
+            _passCount   = 0;
+            _currentSeat = _lastPlaySeat;
+            RpcStartNewTrick(_lastPlaySeat);
+        }
+        else
+        {
+            AdvanceTurn();
+        }
+    }
+
+    // ── Server helpers ─────────────────────────────────────────────────────────
+
+    [Server]
+    private void AdvanceTurn()
+    {
+        _currentSeat = SeatingManager.Instance.NextSeat(_currentSeat);
+    }
+
+    // ── Client RPCs ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applies a validated play on all clients. The result is re-derived locally from
+    /// the cards and current context — all clients share the same ordered RPC stream,
+    /// so context is always in sync when this arrives.
+    /// </summary>
+    [ClientRpc]
+    private void RpcApplyPlay(int seatIndex, Card.CardId[] cards)
+    {
+        var context = new SetValidator.GameContext
+        {
+            MustBeat     = TrickManager.Instance.ControllingSet,
+            RequiredType = TrickManager.Instance.ControllingSet?.Type,
+            TrumpRank    = TrumpRank,
+        };
+        SetValidator.ValidationResult result = SetValidator.Validate(cards, context);
+        TrickManager.Instance.ApplyPlay(seatIndex, cards, result);
+    }
+
+    [ClientRpc]
+    private void RpcApplyPass(int seatIndex)
+    {
+        TrickManager.Instance.ApplyPass(seatIndex);
+    }
+
+    [ClientRpc]
+    private void RpcStartNewTrick(int leadSeatIndex)
+    {
+        TrickManager.Instance.StartTrick();
+        Debug.Log($"[TurnManager] New trick. Leader: seat {leadSeatIndex}");
+    }
+
+    [ClientRpc]
+    private void RpcSyncGameStart(Card.Rank trumpRank)
+    {
+        TrickManager.Instance.SetTrumpRank(trumpRank);
+    }
+
+    /// <summary>Sends rejection feedback only to the player whose action was rejected.</summary>
+    [TargetRpc]
+    private void TargetRpcRejectAction(NetworkConnectionToClient conn, string reason)
+    {
+        Debug.LogWarning($"[TurnManager] Action rejected: {reason}");
+        AnnouncementOverlay.Show(AnnouncementType.Error, reason);
+    }
+
+    // ── SyncVar hook ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Fires on all clients (including host) when _currentSeat changes.
+    /// Gates local input so only the active player can submit actions.
+    /// </summary>
+    private void OnCurrentSeatChanged(int _, int newSeat)
+    {
+        bool isMyTurn = newSeat >= 0 && newSeat == LocalSeat;
+        SelectionManager.Instance.IsPlayerTurn = isMyTurn;
+        Debug.Log($"[TurnManager] Seat {newSeat}'s turn | local seat {LocalSeat} | myTurn={isMyTurn}");
+    }
+}

--- a/Assets/Scripts/GameLogic/TurnManager.cs
+++ b/Assets/Scripts/GameLogic/TurnManager.cs
@@ -39,15 +39,9 @@ public class TurnManager : NetworkBehaviour
     private Card.Rank _trumpRank = Card.Rank.Two;
     public Card.Rank TrumpRank => _trumpRank;
 
-    // ── Dev ───────────────────────────────────────────────────────────────────
+    public int CurrentSeat => _currentSeat;
 
-#if UNITY_EDITOR
-    [Header("Dev")]
-    [Tooltip("Skip lobby and start a local single-player session immediately. Editor only.")]
-    [SerializeField] private bool _devSoloMode = false;
-#endif
-
-    /// <summary>True when running in dev solo mode. Bypasses all network paths.</summary>
+    /// <summary>True in the editor without a network connection. Bypasses all network paths.</summary>
     public static bool IsSoloMode { get; private set; }
 
     // ── Server-only state ──────────────────────────────────────────────────────
@@ -59,9 +53,6 @@ public class TurnManager : NetworkBehaviour
     private int _lastPlaySeat = -1;
 
     // ── Properties ────────────────────────────────────────────────────────────
-
-    /// <summary>Seat index of the local player. -1 until DealManager assigns seating.</summary>
-    public int LocalSeat => Player.LocalPlayer != null ? Player.LocalPlayer.SeatIndex : -1;
 
     // ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -75,7 +66,7 @@ public class TurnManager : NetworkBehaviour
         Instance = this;
 
 #if UNITY_EDITOR
-        IsSoloMode = _devSoloMode;
+        IsSoloMode = !NetworkClient.active;
 #endif
 
         // Subscribe here — Awake runs before Mirror disables scene NetworkBehaviours.
@@ -132,10 +123,10 @@ public class TurnManager : NetworkBehaviour
 
         RpcSyncGameStart(trumpRank);
 
+        TrickManager.Instance.StartTrick();
+
         // _currentSeat SyncVar change triggers OnCurrentSeatChanged on all clients.
         _currentSeat = leadSeat;
-
-        TrickManager.Instance.StartTrick();
         Debug.Log($"[TurnManager] Game started. Lead seat: {leadSeat}, Trump: {trumpRank}");
     }
 
@@ -178,7 +169,7 @@ public class TurnManager : NetworkBehaviour
         _passCount    = 0;
         _lastPlaySeat = seat;
 
-        RpcApplyPlay(seat, cards);
+        RpcApplyPlay(seat, cards, result.Type, result.KeyRank, result.Description);
         AdvanceTurn();
     }
 
@@ -227,20 +218,19 @@ public class TurnManager : NetworkBehaviour
     // ── Client RPCs ────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Applies a validated play on all clients. The result is re-derived locally from
-    /// the cards and current context — all clients share the same ordered RPC stream,
-    /// so context is always in sync when this arrives.
+    /// Applies a server-validated play on all clients. The result fields are passed
+    /// directly from the server — no re-validation needed on the client.
     /// </summary>
     [ClientRpc]
-    private void RpcApplyPlay(int seatIndex, Card.CardId[] cards)
+    private void RpcApplyPlay(int seatIndex, Card.CardId[] cards, SetValidator.SetType type, Card.Rank keyRank, string description)
     {
-        var context = new SetValidator.GameContext
+        var result = new SetValidator.ValidationResult
         {
-            MustBeat     = TrickManager.Instance.ControllingSet,
-            RequiredType = TrickManager.Instance.ControllingSet?.Type,
-            TrumpRank    = TrumpRank,
+            IsValid     = true,
+            Type        = type,
+            KeyRank     = keyRank,
+            Description = description,
         };
-        SetValidator.ValidationResult result = SetValidator.Validate(cards, context);
         TrickManager.Instance.ApplyPlay(seatIndex, cards, result);
     }
 
@@ -280,10 +270,9 @@ public class TurnManager : NetworkBehaviour
     /// </summary>
     public void DevStartSolo()
     {
-        IsSoloMode = true;
         TrickManager.Instance.SetTrumpRank(Card.Rank.Two);
         TrickManager.Instance.StartTrick();
-        // SelectionManager.Instance.IsPlayerTurn = true;
+        SelectionManager.Instance.IsPlayerTurn = true;
         Debug.Log("[TurnManager] Dev solo mode active — local player has the turn.");
     }
 #endif
@@ -295,9 +284,11 @@ public class TurnManager : NetworkBehaviour
     /// Gates local input so only the active player can submit actions.
     /// </summary>
     private void OnCurrentSeatChanged(int _, int newSeat)
+    
     {
-        bool isMyTurn = newSeat >= 0 && newSeat == LocalSeat;
+        int localSeat = Player.LocalPlayer != null ? Player.LocalPlayer.SeatIndex : -1;
+        bool isMyTurn = newSeat >= 0 && newSeat == localSeat;
         SelectionManager.Instance.IsPlayerTurn = isMyTurn;
-        Debug.Log($"[TurnManager] Seat {newSeat}'s turn | local seat {LocalSeat} | myTurn={isMyTurn}");
+        Debug.Log($"[TurnManager] Seat {newSeat}'s turn | local seat {localSeat} | myTurn={isMyTurn}");
     }
 }

--- a/Assets/Scripts/GameLogic/TurnManager.cs
+++ b/Assets/Scripts/GameLogic/TurnManager.cs
@@ -123,8 +123,6 @@ public class TurnManager : NetworkBehaviour
 
         RpcSyncGameStart(trumpRank);
 
-        TrickManager.Instance.StartTrick();
-
         // _currentSeat SyncVar change triggers OnCurrentSeatChanged on all clients.
         _currentSeat = leadSeat;
         Debug.Log($"[TurnManager] Game started. Lead seat: {leadSeat}, Trump: {trumpRank}");
@@ -251,6 +249,7 @@ public class TurnManager : NetworkBehaviour
     private void RpcSyncGameStart(Card.Rank trumpRank)
     {
         TrickManager.Instance.SetTrumpRank(trumpRank);
+        TrickManager.Instance.StartTrick();
     }
 
     /// <summary>Sends rejection feedback only to the player whose action was rejected.</summary>

--- a/Assets/Scripts/GameLogic/TurnManager.cs
+++ b/Assets/Scripts/GameLogic/TurnManager.cs
@@ -79,8 +79,11 @@ public class TurnManager : NetworkBehaviour
     private void OnDestroy()
     {
         if (Instance == this) Instance = null;
-        SelectionManager.Instance.SelectionCommitted -= OnLocalCommit;
-        SelectionManager.Instance.Passed             -= OnLocalPass;
+        if (SelectionManager.Instance != null)
+        {
+            SelectionManager.Instance.SelectionCommitted -= OnLocalCommit;
+            SelectionManager.Instance.Passed             -= OnLocalPass;
+        }
     }
 
     // ── Local event handlers → Commands ───────────────────────────────────────

--- a/Assets/Scripts/GameLogic/TurnManager.cs
+++ b/Assets/Scripts/GameLogic/TurnManager.cs
@@ -39,6 +39,17 @@ public class TurnManager : NetworkBehaviour
     private Card.Rank _trumpRank = Card.Rank.Two;
     public Card.Rank TrumpRank => _trumpRank;
 
+    // ── Dev ───────────────────────────────────────────────────────────────────
+
+#if UNITY_EDITOR
+    [Header("Dev")]
+    [Tooltip("Skip lobby and start a local single-player session immediately. Editor only.")]
+    [SerializeField] private bool _devSoloMode = false;
+#endif
+
+    /// <summary>True when running in dev solo mode. Bypasses all network paths.</summary>
+    public static bool IsSoloMode { get; private set; }
+
     // ── Server-only state ──────────────────────────────────────────────────────
 
     /// <summary>Consecutive passes since the last play. Reset to 0 whenever a card set is played.</summary>
@@ -62,32 +73,34 @@ public class TurnManager : NetworkBehaviour
             return;
         }
         Instance = this;
+
+#if UNITY_EDITOR
+        IsSoloMode = _devSoloMode;
+#endif
+
+        // Subscribe here — Awake runs before Mirror disables scene NetworkBehaviours.
+        // C# delegate subscriptions persist regardless of component enabled state.
+        SelectionManager.Instance.IsPlayerTurn = false;
+        SelectionManager.Instance.SelectionCommitted += OnLocalCommit;
+        SelectionManager.Instance.Passed             += OnLocalPass;
     }
 
     private void OnDestroy()
     {
         if (Instance == this) Instance = null;
-    }
-
-    private void OnEnable()
-    {
-        // Disable input until TurnManager assigns the turn.
-        SelectionManager.Instance.IsPlayerTurn = false;
-
-        SelectionManager.Instance.SelectionCommitted += OnLocalCommit;
-        SelectionManager.Instance.Passed             += OnLocalPass;
-    }
-
-    private void OnDisable()
-    {
         SelectionManager.Instance.SelectionCommitted -= OnLocalCommit;
         SelectionManager.Instance.Passed             -= OnLocalPass;
     }
 
     // ── Local event handlers → Commands ───────────────────────────────────────
 
-    private void OnLocalCommit(IReadOnlyList<Card.CardId> cards, SetValidator.ValidationResult _)
+    private void OnLocalCommit(IReadOnlyList<Card.CardId> cards, SetValidator.ValidationResult result)
     {
+        if (IsSoloMode)
+        {
+            TrickManager.Instance.ApplyPlay(0, cards, result);
+            return;
+        }
         if (Player.LocalPlayer == null) return;
         var arr = new Card.CardId[cards.Count];
         for (int i = 0; i < cards.Count; i++) arr[i] = cards[i];
@@ -96,7 +109,12 @@ public class TurnManager : NetworkBehaviour
 
     private void OnLocalPass()
     {
-        Player.LocalPlayer?.CmdPass();
+        if (IsSoloMode)
+        {
+            TrickManager.Instance.StartTrick();
+            return;
+        }
+        if (Player.LocalPlayer != null) Player.LocalPlayer.CmdPass();
     }
 
     // ── Public server API ──────────────────────────────────────────────────────
@@ -252,6 +270,23 @@ public class TurnManager : NetworkBehaviour
         Debug.LogWarning($"[TurnManager] Action rejected: {reason}");
         AnnouncementOverlay.Show(AnnouncementType.Error, reason);
     }
+
+    // ── Dev helpers ───────────────────────────────────────────────────────────
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Bypasses networking and lobby for editor solo testing.
+    /// Gives the local player turn control and opens the first trick.
+    /// </summary>
+    public void DevStartSolo()
+    {
+        IsSoloMode = true;
+        TrickManager.Instance.SetTrumpRank(Card.Rank.Two);
+        TrickManager.Instance.StartTrick();
+        // SelectionManager.Instance.IsPlayerTurn = true;
+        Debug.Log("[TurnManager] Dev solo mode active — local player has the turn.");
+    }
+#endif
 
     // ── SyncVar hook ───────────────────────────────────────────────────────────
 

--- a/Assets/Scripts/GameLogic/TurnManager.cs.meta
+++ b/Assets/Scripts/GameLogic/TurnManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3435844ea8ddc8f4a91c739d3b96b192

--- a/Assets/Scripts/HandManager.cs
+++ b/Assets/Scripts/HandManager.cs
@@ -105,8 +105,10 @@ public class HandManager : MonoBehaviour
                 if (!NetworkClient.active)
                 {
                     DealNewHand();
+                    #if UNITY_EDITOR
                     if (TurnManager.IsSoloMode)
                         TurnManager.Instance.DevStartSolo();
+                    #endif
                 }
         #endif
     }

--- a/Assets/Scripts/HandManager.cs
+++ b/Assets/Scripts/HandManager.cs
@@ -103,7 +103,11 @@ public class HandManager : MonoBehaviour
 
         #if UNITY_EDITOR || DEV_BUILD
                 if (!NetworkClient.active)
+                {
                     DealNewHand();
+                    if (TurnManager.IsSoloMode)
+                        TurnManager.Instance.DevStartSolo();
+                }
         #endif
     }
 

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -23,6 +23,12 @@ public class DealManager : NetworkBehaviour
 
     private bool _hasDealt;
 
+    /// <summary>
+    /// Server-side copy of each player's remaining hand, keyed by netId.
+    /// Used by TurnManager to verify a player holds the cards they claim to play.
+    /// </summary>
+    private readonly Dictionary<uint, HashSet<Card.CardId>> _serverHands = new();
+
     private void Awake()  => Instance = this;
     private void OnDestroy() { if (Instance == this) Instance = null; }
 
@@ -38,7 +44,6 @@ public class DealManager : NetworkBehaviour
         foreach (var conn in NetworkServer.connections.Values)
             if (conn.identity == null) return; // at least one Player not yet spawned
 
-        DealCards();
         _hasDealt = true;
         DealCards();
     }
@@ -97,11 +102,36 @@ public class DealManager : NetworkBehaviour
         #endif
         Debug.Log($"[DealManager] Dealing {deck.Count} cards to {players.Count} players ({handSize} each, seed={seed})");
 
+        _serverHands.Clear();
         for (int i = 0; i < players.Count; i++)
         {
+            players[i].SeatIndex = i;
             var hand = deck.GetRange(i * handSize, handSize).ToArray();
+            _serverHands[players[i].netId] = new HashSet<Card.CardId>(hand);
             TargetRpcReceiveHand(players[i].connectionToClient, hand);
         }
+
+        // Seat 0 leads the first trick; trump rank defaults to Two until round scoring is implemented.
+        if (TurnManager.Instance != null)
+            TurnManager.Instance.StartGame(leadSeat: 0, trumpRank: Card.Rank.Two);
+        else
+            Debug.LogError("[DealManager] TurnManager.Instance is null — turn management will not start.");
+    }
+
+    /// <summary>
+    /// Checks that <paramref name="netId"/> holds all <paramref name="cards"/>, then removes
+    /// them from the server-side hand. Returns false (and removes nothing) if any card is missing.
+    /// Called by TurnManager before accepting a play.
+    /// </summary>
+    [Server]
+    public bool TryConsumeCards(uint netId, Card.CardId[] cards)
+    {
+        if (!_serverHands.TryGetValue(netId, out var hand)) return false;
+        foreach (var card in cards)
+            if (!hand.Contains(card)) return false;
+        foreach (var card in cards)
+            hand.Remove(card);
+        return true;
     }
 
     /// <summary>Sends a player their hand. Only the targeted client receives this message.</summary>

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -22,6 +22,7 @@ public class DealManager : NetworkBehaviour
     [SerializeField] private readonly int _devHandSize = 26;
 
     private bool _hasDealt;
+    private int _readyCount;
 
     /// <summary>
     /// Server-side copy of each player's remaining hand, keyed by netId.
@@ -33,16 +34,18 @@ public class DealManager : NetworkBehaviour
     private void OnDestroy() { if (Instance == this) Instance = null; }
 
     /// <summary>
-    /// Called by GuandanNetworkManager.OnServerAddPlayer each time a client has their
-    /// Player object spawned in GameScene. Deals once all connected clients are ready.
+    /// Called via Player.CmdClientReady after OnStartLocalPlayer completes on each client.
+    /// Guarantees Player.LocalPlayer is set on every client before dealing begins.
+    /// Deals once all connected clients have confirmed ready.
     /// </summary>
     [Server]
-    public void OnConnectionReady()
+    public void OnClientReady()
     {
+        Debug.Log($"[DealManager] OnClientReady — _readyCount={_readyCount}, connections={NetworkServer.connections.Count}, _hasDealt={_hasDealt}");
         if (_hasDealt) return;
 
-        foreach (var conn in NetworkServer.connections.Values)
-            if (conn.identity == null) return; // at least one Player not yet spawned
+        _readyCount++;
+        if (_readyCount < NetworkServer.connections.Count) return;
 
         _hasDealt = true;
         DealCards();

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -41,7 +41,6 @@ public class DealManager : NetworkBehaviour
     [Server]
     public void OnClientReady()
     {
-        Debug.Log($"[DealManager] OnClientReady — _readyCount={_readyCount}, connections={NetworkServer.connections.Count}, _hasDealt={_hasDealt}");
         if (_hasDealt) return;
 
         _readyCount++;

--- a/Assets/Scripts/Networking/DealManager.cs
+++ b/Assets/Scripts/Networking/DealManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Mirror;
 
@@ -129,8 +130,7 @@ public class DealManager : NetworkBehaviour
     public bool TryConsumeCards(uint netId, Card.CardId[] cards)
     {
         if (!_serverHands.TryGetValue(netId, out var hand)) return false;
-        foreach (var card in cards)
-            if (!hand.Contains(card)) return false;
+        if (!cards.All(hand.Contains)) return false;
         foreach (var card in cards)
             hand.Remove(card);
         return true;

--- a/Assets/Scripts/Networking/GuandanNetworkManager.cs
+++ b/Assets/Scripts/Networking/GuandanNetworkManager.cs
@@ -29,9 +29,6 @@ public class GuandanNetworkManager : NetworkManager
     {
         base.OnServerAddPlayer(conn);
         Debug.Log($"[Server] Player spawned for connId={conn.connectionId}");
-
-        if (SceneManager.GetActiveScene().name == "GameScene")
-            DealManager.Instance?.OnConnectionReady();
     }
 
     // CLIENT-SIDE: logs appear in the joining client's console

--- a/Assets/Scripts/Networking/Player.cs
+++ b/Assets/Scripts/Networking/Player.cs
@@ -32,6 +32,7 @@ public class Player : NetworkBehaviour
     {
         LocalPlayer = this;
         Debug.Log($"[Client] Local player started: netId={netId}");
+        CmdClientReady();
     }
 
     [Command]
@@ -43,6 +44,16 @@ public class Player : NetworkBehaviour
         Debug.Log($"[Server] Player {playerName} (connId={connectionToClient.connectionId}) is leaving.");
         if (LobbyManager.Instance != null)
             LobbyManager.Instance.RefreshPlayerSlots();
+    }
+
+    /// <summary>
+    /// Sent after OnStartLocalPlayer completes, guaranteeing Player.LocalPlayer is set
+    /// on this client before the server proceeds with dealing.
+    /// </summary>
+    [Command]
+    public void CmdClientReady()
+    {
+        if (DealManager.Instance != null) DealManager.Instance.OnClientReady();
     }
 
     /// <summary>Sends the local player's card play to the server for validation and broadcast.</summary>

--- a/Assets/Scripts/Networking/Player.cs
+++ b/Assets/Scripts/Networking/Player.cs
@@ -3,9 +3,14 @@ using Mirror;
 
 public class Player : NetworkBehaviour
 {
+    /// <summary>The local player's Player instance. Set in OnStartLocalPlayer.</summary>
+    public static Player LocalPlayer { get; private set; }
+
     [SyncVar] public string playerName;
     [SyncVar(hook = nameof(OnReadyChanged))] public bool isReady;
     [SyncVar] public bool isHost;
+    /// <summary>Clockwise seat index assigned by DealManager. -1 until seating is built.</summary>
+    [SyncVar] public int SeatIndex = -1;
 
     public override void OnStartServer()
     {
@@ -15,16 +20,17 @@ public class Player : NetworkBehaviour
 
     public override void OnStartClient()
     {
-        LobbyManager.Instance?.RefreshPlayerSlots();
+        if (LobbyManager.Instance != null) LobbyManager.Instance.RefreshPlayerSlots();
     }
 
     public override void OnStopClient()
     {
-        LobbyManager.Instance?.RefreshPlayerSlots();
+        if (LobbyManager.Instance != null) LobbyManager.Instance.RefreshPlayerSlots();
     }
 
     public override void OnStartLocalPlayer()
     {
+        LocalPlayer = this;
         Debug.Log($"[Client] Local player started: netId={netId}");
     }
 
@@ -39,6 +45,22 @@ public class Player : NetworkBehaviour
             LobbyManager.Instance.RefreshPlayerSlots();
     }
 
+    /// <summary>Sends the local player's card play to the server for validation and broadcast.</summary>
+    [Command]
+    public void CmdPlayCards(Card.CardId[] cards)
+    {
+        if (TurnManager.Instance != null) TurnManager.Instance.ServerHandlePlay(this, cards);
+    }
+
+    /// <summary>Sends the local player's pass to the server.</summary>
+    [Command]
+    public void CmdPass()
+    {
+        if (TurnManager.Instance != null) TurnManager.Instance.ServerHandlePass(this);
+    }
+
     void OnReadyChanged(bool _, bool __)
-        => LobbyManager.Instance?.RefreshPlayerSlots();
+    {
+        if (LobbyManager.Instance != null) LobbyManager.Instance.RefreshPlayerSlots();
+    }
 }

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -31,6 +31,12 @@ public class SelectionManager
     /// <summary>Fired when selection is explicitly cleared (Clear or Pass).</summary>
     public event Action SelectionCleared;
 
+    /// <summary>
+    /// Fired specifically when the player passes their turn (not on a plain Clear).
+    /// TurnManager subscribes to forward this to the server via CmdPass.
+    /// </summary>
+    public event Action Passed;
+
     /// <summary>Fired when Commit is attempted but SetValidator rejects the set.</summary>
     public event Action<SetValidator.ValidationResult> CommitFailed;
 
@@ -99,13 +105,14 @@ public class SelectionManager
         SelectionChanged?.Invoke(_staged);
     }
 
-    /// <summary>Clear selection and pass the turn (turn advance wired by TurnManager later).</summary>
+    /// <summary>Clear selection and pass the turn. TurnManager forwards this to the server.</summary>
     public void Pass()
     {
         if (!IsPlayerTurn) return;
         _staged.Clear();
         SelectionCleared?.Invoke();
         SelectionChanged?.Invoke(_staged);
+        Passed?.Invoke();
     }
 
     /// <summary>Injected by TurnManager when turn context changes (required type, must-beat set).</summary>

--- a/Assets/Scripts/SelectionManager.cs
+++ b/Assets/Scripts/SelectionManager.cs
@@ -75,7 +75,12 @@ public class SelectionManager
         if (!IsPlayerTurn)
         {
             if (_staged.Count > 0)
+            {
+                _staged.Clear();
                 CommitFailed?.Invoke(new SetValidator.ValidationResult { IsValid = false, Code = SetValidator.FailCode.NotYourTurn, FailReason = "Not your turn" });
+                SelectionCleared?.Invoke();
+                SelectionChanged?.Invoke(_staged);
+            }
             return false;
         }
         if (_staged.Count == 0) return false;

--- a/Assets/Scripts/UI/GameHUD.cs
+++ b/Assets/Scripts/UI/GameHUD.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Bridges UI button events to game actions.
+/// Attach to the HUD or ActionBar GameObject and wire buttons in the Inspector.
+/// </summary>
+public class GameHUD : MonoBehaviour
+{
+    public void OnPassClicked() => SelectionManager.Instance.Pass();
+
+    public void OnPlayClicked() => SelectionManager.Instance.Commit();
+}

--- a/Assets/Scripts/UI/GameHUD.cs.meta
+++ b/Assets/Scripts/UI/GameHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de1592ce675dc8348a24911d743dabf0

--- a/Assets/Scripts/UI/TableDisplay.cs
+++ b/Assets/Scripts/UI/TableDisplay.cs
@@ -141,7 +141,7 @@ public class TableDisplay : MonoBehaviour, IPointerClickHandler, IDropHandler
     private void OnRemoteSetPlayed(TrickManager.PlayRecord record)
     {
         if (TurnManager.IsSoloMode) return; // local play already handled by OnCardsPlayed
-        int localSeat = TurnManager.Instance != null ? TurnManager.Instance.LocalSeat : -1;
+        int localSeat = Player.LocalPlayer != null ? Player.LocalPlayer.SeatIndex : -1;
         if (record.PlayerId == localSeat) return; // local play already handled by OnCardsPlayed
 
         StopAllCoroutines();

--- a/Assets/Scripts/UI/TableDisplay.cs
+++ b/Assets/Scripts/UI/TableDisplay.cs
@@ -66,12 +66,14 @@ public class TableDisplay : MonoBehaviour, IPointerClickHandler, IDropHandler
     {
         HandManager.CardsPlayed    += OnCardsPlayed;
         _trickManager.TrickStarted += OnTrickStarted;
+        _trickManager.SetPlayed    += OnRemoteSetPlayed;
     }
 
     private void OnDisable()
     {
         HandManager.CardsPlayed    -= OnCardsPlayed;
         _trickManager.TrickStarted -= OnTrickStarted;
+        _trickManager.SetPlayed    -= OnRemoteSetPlayed;
 
         StopAllCoroutines();
         DestroyAll(_currentCards);
@@ -127,6 +129,49 @@ public class TableDisplay : MonoBehaviour, IPointerClickHandler, IDropHandler
             var jitter = new Vector2(
                 UnityEngine.Random.Range(-_placementJitter, _placementJitter),
                 UnityEngine.Random.Range(-_placementJitter, _placementJitter));
+            StartCoroutine(FlyToTarget(rt, new Vector2(startX + i * _cardSpacing, 0f) + jitter,
+                                       Vector3.one * _cardDisplayScale));
+        }
+    }
+
+    /// <summary>
+    /// Renders a play from a remote player by spawning fresh card GameObjects at the table centre.
+    /// Skipped for the local player because HandManager.CardsPlayed already animated those cards.
+    /// </summary>
+    private void OnRemoteSetPlayed(TrickManager.PlayRecord record)
+    {
+        int localSeat = TurnManager.Instance != null ? TurnManager.Instance.LocalSeat : -1;
+        if (record.PlayerId == localSeat) return; // local play already handled by OnCardsPlayed
+
+        StopAllCoroutines();
+        DestroyAll(_exitingCards);
+
+        foreach (var go in _currentCards)
+        {
+            if (go == null) continue;
+            var brt = go.GetComponent<RectTransform>();
+            _previousCards.Add(go);
+            StartCoroutine(FlyToTarget(brt, brt.anchoredPosition + _stackOffset, Vector3.one * _cardDisplayScale));
+        }
+        _currentCards.Clear();
+
+        var cards = record.Cards;
+        float totalWidth = (cards.Count - 1) * _cardSpacing;
+        float startX     = -totalWidth * 0.5f;
+
+        for (int i = 0; i < cards.Count; i++)
+        {
+            GameObject go = _cardManager.SpawnCard(cards[i], _cardContainer);
+            if (go == null) continue;
+
+            DisableInteraction(go);
+            var rt = go.GetComponent<RectTransform>();
+            // Start at the table centre then animate to the final spread position.
+            rt.anchoredPosition = Vector2.zero;
+            var jitter = new Vector2(
+                UnityEngine.Random.Range(-_placementJitter, _placementJitter),
+                UnityEngine.Random.Range(-_placementJitter, _placementJitter));
+            _currentCards.Add(go);
             StartCoroutine(FlyToTarget(rt, new Vector2(startX + i * _cardSpacing, 0f) + jitter,
                                        Vector3.one * _cardDisplayScale));
         }

--- a/Assets/Scripts/UI/TableDisplay.cs
+++ b/Assets/Scripts/UI/TableDisplay.cs
@@ -140,6 +140,7 @@ public class TableDisplay : MonoBehaviour, IPointerClickHandler, IDropHandler
     /// </summary>
     private void OnRemoteSetPlayed(TrickManager.PlayRecord record)
     {
+        if (TurnManager.IsSoloMode) return; // local play already handled by OnCardsPlayed
         int localSeat = TurnManager.Instance != null ? TurnManager.Instance.LocalSeat : -1;
         if (record.PlayerId == localSeat) return; // local play already handled by OnCardsPlayed
 

--- a/Assets/Scripts/UI/TableDisplay.cs
+++ b/Assets/Scripts/UI/TableDisplay.cs
@@ -140,16 +140,18 @@ public class TableDisplay : MonoBehaviour, IPointerClickHandler, IDropHandler
     /// </summary>
     private void OnRemoteSetPlayed(TrickManager.PlayRecord record)
     {
-        if (TurnManager.IsSoloMode) return; // local play already handled by OnCardsPlayed
+        // In solo mode Player.LocalPlayer is never set, so localSeat would be -1.
+        // record.PlayerId is 0 in solo mode, so the seat guard below would not skip it,
+        // causing double-rendering. Early return here is load-bearing.
+        if (TurnManager.IsSoloMode) return;
         int localSeat = Player.LocalPlayer != null ? Player.LocalPlayer.SeatIndex : -1;
         if (record.PlayerId == localSeat) return; // local play already handled by OnCardsPlayed
 
         StopAllCoroutines();
         DestroyAll(_exitingCards);
 
-        foreach (var go in _currentCards)
+        foreach (var go in _currentCards.Where(go => go != null))
         {
-            if (go == null) continue;
             var brt = go.GetComponent<RectTransform>();
             _previousCards.Add(go);
             StartCoroutine(FlyToTarget(brt, brt.anchoredPosition + _stackOffset, Vector3.one * _cardDisplayScale));

--- a/Assets/Scripts/UI/TrickHistoryOverlay.cs
+++ b/Assets/Scripts/UI/TrickHistoryOverlay.cs
@@ -64,8 +64,17 @@ public class TrickHistoryOverlay : MonoBehaviour
         if (Instance == this) Instance = null;
     }
 
-    private void OnEnable()  => _trickManager.TrickStarted += OnTrickStarted;
-    private void OnDisable() => _trickManager.TrickStarted -= OnTrickStarted;
+    private void OnEnable()
+    {
+        _trickManager.TrickStarted += OnTrickStarted;
+        _trickManager.SetPlayed    += OnSetPlayed;
+    }
+
+    private void OnDisable()
+    {
+        _trickManager.TrickStarted -= OnTrickStarted;
+        _trickManager.SetPlayed    -= OnSetPlayed;
+    }
 
     // ── Public API ────────────────────────────────────────────────────────────
 
@@ -84,6 +93,23 @@ public class TrickHistoryOverlay : MonoBehaviour
     // ── Private ──────────────────────────────────────────────────────────────
 
     private void OnTrickStarted() => HideImmediate();
+
+    private void OnSetPlayed(TrickManager.PlayRecord record)
+    {
+        // Only update if the overlay is currently visible.
+        if (_canvasGroup.alpha <= 0f && !_canvasGroup.blocksRaycasts) return;
+        int index = _entries.Count;
+        float totalHeight = (index + 1) * _rowHeight + _padding * 2f;
+        _panel.sizeDelta  = new Vector2(_panelWidth, totalHeight);
+        float topY = totalHeight * 0.5f - _padding - _rowHeight * 0.5f;
+        // Reposition existing rows.
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            var rt = _entries[i].GetComponent<RectTransform>();
+            if (rt != null) rt.anchoredPosition = new Vector2(0f, topY - i * _rowHeight);
+        }
+        _entries.Add(BuildRow(record, index, topY - index * _rowHeight));
+    }
 
     private void DoShow(IReadOnlyList<TrickManager.PlayRecord> history)
     {

--- a/Assets/Scripts/UI/TrickHistoryOverlay.cs
+++ b/Assets/Scripts/UI/TrickHistoryOverlay.cs
@@ -190,7 +190,7 @@ public class TrickHistoryOverlay : MonoBehaviour
         tmp.enableAutoSizing     = true;
         tmp.fontSizeMin          = 16f;
         tmp.fontSizeMax          = 28f;
-        tmp.enableWordWrapping   = false;
+        tmp.textWrappingMode     = TextWrappingModes.NoWrap;
         tmp.color                = Color.white;
     }
 

--- a/Assets/Settings/Build Profiles/Development_Windows.asset
+++ b/Assets/Settings/Build Profiles/Development_Windows.asset
@@ -107,7 +107,7 @@ MonoBehaviour:
     - line: '|   androidApplicationEntry: 2'
     - line: '|   defaultIsNativeResolution: 1'
     - line: '|   macRetinaSupport: 1'
-    - line: '|   runInBackground: 0'
+    - line: '|   runInBackground: 1'
     - line: '|   muteOtherAudioSources: 0'
     - line: '|   Prepare IOS For Recording: 0'
     - line: '|   Force IOS Speakers When Recording: 0'


### PR DESCRIPTION
## Server-Authoritative Turn & Action Synchronization

### Summary

Implements the full networked action pipeline for Guandan. Every card play and pass is sent to the server, validated, and broadcast to all clients so all players see the same game state. Illegal plays are rejected server-side before they can affect state.

**Core networking pipeline (`TurnManager`, `Player`, `DealManager`):**
- New `TurnManager` NetworkBehaviour owns turn order and action validation. All client actions (play, pass) go through `CmdPlayCards` / `CmdPass` on `Player`, routed to `ServerHandlePlay` / `ServerHandlePass`
- Server validates plays via `SetValidator` and verifies the player actually holds the cards (`TryConsumeCards` in `DealManager`)
- Accepted plays broadcast via `RpcApplyPlay` with result fields passed directly — no re-validation on clients
- Accepted passes broadcast via `RpcApplyPass`; when all other players pass, `RpcStartNewTrick` fires and the last player to play leads
- Rejected actions send `TargetRpcRejectAction` back to the offending client only, with a reason string shown in `AnnouncementOverlay`
- Turn enforcement via `_currentSeat` SyncVar hook — `IsPlayerTurn` is only set true on the correct client

**`SelectionManager` fixes:**
- Added `Passed` event wired to the pass flow
- Fixed cards getting stuck when playing out of turn: staged selection is now cleared and events fired on a failed `Commit`, so cards return to their resting position

**Dev solo mode:**
- `TurnManager.IsSoloMode` flag (editor-only) bypasses all Mirror paths so the game can be tested in the editor without going through the lobby. `HandManager` auto-deals and calls `DevStartSolo` to give the local player the turn

**Game HUD (`GameHUD`, scene):**
- Added Play and Pass buttons anchored to the bottom of the screen, wired to `SelectionManager.Commit` and `SelectionManager.Pass`

**Hover suppression during drag (`CardHover`):**
- `CardHover` now subscribes to `CardDrag.AnyDragBegin/AnyDragEnd` and sets a static `IsDragging` flag. `OnPointerEnter` is suppressed while any drag is active; any card that was already hovered when a drag begins has its hover state cleared immediately

**Trick history live updates (`TrickHistoryOverlay`):**
- Overlay now subscribes to `TrickManager.SetPlayed` while visible. New plays append a row in real time instead of requiring the overlay to be closed and reopened


https://github.com/user-attachments/assets/cb081dcb-77c3-464a-82fc-a085ff92807b

